### PR TITLE
BUGFIX: Deleting inputs caused de-sync on tally mappings

### DIFF
--- a/tally/source.go
+++ b/tally/source.go
@@ -91,7 +91,7 @@ func (source Source) updateState(state *State) error {
 
 	system := source.system
 
-	for sourceID, systemSource := range system.SrcMgr.SourceCol.List() {
+	for sourceID, systemSource := range system.SrcMgr.SourceCol {
 		// lookup Input from inputCfg with tally=
 		if systemSource.InputCfgIndex < 0 {
 			continue


### PR DESCRIPTION
Deleting some inputs caused the tally mappings to go off-by-one.