### PR TITLE
Fix handling of v5 EC-200 discovery packets for non-VP hosts

### DIFF
--- a/client/discovery.go
+++ b/client/discovery.go
@@ -15,6 +15,11 @@ func (options Options) DiscoverOptions(discoveryPacket discovery.Packet) (Option
 }
 
 func (options Options) DiscoverFilter(discoveryPacket discovery.Packet) bool {
+	// do not connect to non-VPs
+	if discoveryPacket.XMLPort == 0 {
+		return false
+	}
+
 	// do not connect to slave VPs
 	if discoveryPacket.MasterMac != discoveryPacket.MacAddress {
 		return false

--- a/discovery/packet.go
+++ b/discovery/packet.go
@@ -22,6 +22,18 @@ type Packet struct {
 	Type       string
 }
 
+func unpackInt(field string, value string, ptr *int) error {
+	if value == "N/A" {
+		return nil
+	}
+
+	if _, err := fmt.Sscanf(value, "%d", ptr); err != nil {
+		return fmt.Errorf("Invalid %v=%#v: %v", field, value, err)
+	}
+
+	return nil
+}
+
 func (packet *Packet) unpackHostname(hostname string) error {
 	parts := strings.Split(hostname, ":")
 
@@ -29,24 +41,24 @@ func (packet *Packet) unpackHostname(hostname string) error {
 		packet.Hostname = parts[0]
 	}
 	if len(parts) > 1 {
-		if _, err := fmt.Sscanf(parts[1], "%d", &packet.XMLPort); err != nil {
-			return fmt.Errorf("Invalid XMLPort=%#v: %v", parts[1], err)
+		if err := unpackInt("XMLPort", parts[1], &packet.XMLPort); err != nil {
+			return err
 		}
 	}
 	if len(parts) > 2 {
 		packet.Name = parts[2]
 	}
 	if len(parts) > 3 {
-		if _, err := fmt.Sscanf(parts[3], "%d", &packet.UnitID); err != nil {
-			return fmt.Errorf("Invalid UnitID=%#v: %v", parts[3], err)
+		if err := unpackInt("UnitID", parts[3], &packet.UnitID); err != nil {
+			return err
 		}
 	}
 	if len(parts) > 4 {
-		if _, err := fmt.Sscanf(parts[4], "%d", &packet.VPCount); err != nil {
-			return fmt.Errorf("Invalid VPCount=%#v: %v", parts[4], err)
+		if err := unpackInt("VPCount", parts[4], &packet.VPCount); err != nil {
+			return err
 		}
 	}
-	if len(parts) > 5 {
+	if len(parts) > 5 && parts[5] != "N/A" {
 		packet.MasterMac = strings.Replace(parts[5], "$", ":", -1)
 	}
 	if len(parts) > 6 {

--- a/discovery/packet.go
+++ b/discovery/packet.go
@@ -24,6 +24,7 @@ type Packet struct {
 
 func unpackInt(field string, value string, ptr *int) error {
 	if value == "N/A" {
+		*ptr = 0
 		return nil
 	}
 

--- a/discovery/packet_test.go
+++ b/discovery/packet_test.go
@@ -42,20 +42,20 @@ var testPacket = Packet{
 	Type:       "E2",
 }
 
-func testDecodePacket(t *testing.T, expected Packet, data []byte) {
+func testDecodePacket(t *testing.T, data []byte, expected Packet) {
 	var udpAddr = &net.UDPAddr{IP: net.IP{127, 0, 0, 1}, Port: 1337}
 	var actual Packet
 
 	expected.IP = udpAddr.IP
 
 	if err := actual.unpack(udpAddr, data); err != nil {
-		assert.Errorf(t, err, "packet.unpack(...)")
+		assert.NoErrorf(t, err, "packet.unpack(...)")
+	} else {
+		assert.Equalf(t, expected, actual, "packet.unpack(...)")
 	}
-
-	assert.Equalf(t, expected, actual, "packet.unpack(...)")
 }
 
-func testDecodePacketError(t *testing.T, expected string, data []byte) {
+func testDecodePacketError(t *testing.T, data []byte, expected string) {
 	var udpAddr = &net.UDPAddr{IP: net.IP{127, 0, 0, 1}, Port: 1337}
 	var actual Packet
 
@@ -65,12 +65,12 @@ func testDecodePacketError(t *testing.T, expected string, data []byte) {
 }
 
 func TestDecodePacket(t *testing.T) {
-	testDecodePacket(t, testPacket, testPacketBytes)
+	testDecodePacket(t, testPacketBytes, testPacket)
 }
 
 func TestDecodePacketInvalidSep(t *testing.T) {
-	testDecodePacketError(t, `Invalid field: []byte{0x66, 0x6f, 0x6f}`, []byte("foo\x00bar"))
+	testDecodePacketError(t, []byte("foo\x00bar"), `Invalid field: []byte{0x66, 0x6f, 0x6f}`)
 }
 func TestDecodePacketInvalidHostname(t *testing.T) {
-	testDecodePacketError(t, `Invalid hostname="foo:bar": Invalid XMLPort="bar": expected integer`, []byte("hostname=foo:bar"))
+	testDecodePacketError(t, []byte("hostname=foo:bar"), `Invalid hostname="foo:bar": Invalid XMLPort="bar": expected integer`)
 }

--- a/discovery/packet_test.go
+++ b/discovery/packet_test.go
@@ -74,3 +74,23 @@ func TestDecodePacketInvalidSep(t *testing.T) {
 func TestDecodePacketInvalidHostname(t *testing.T) {
 	testDecodePacketError(t, []byte("hostname=foo:bar"), `Invalid hostname="foo:bar": Invalid XMLPort="bar": expected integer`)
 }
+
+func TestDecodePacket_EC200(t *testing.T) {
+	testDecodePacket(t, decodeTestPacket(`
+		686f 7374
+		6e61 6d65 3d45 432d 3230 303a 4e2f 413a
+		5379 7374 656d 313a 303a 4e2f 413a 4e2f
+		413a 352e 302e 3335 3437 3900 6970 2d61
+		6464 7265 7373 3d31 3932 2e31 3638 2e30
+		2e31 3830 006d 6163 2d61 6464 7265 7373
+		3d30 303a 3062 3a61 623a 3938 3a62 613a
+		6366 0074 7970 653d 4543 2d32 3030 00
+	`), Packet{
+		Hostname:   "EC-200",
+		Name:       "System1",
+		Version:    "5.0.35479",
+		IPAddress:  "192.168.0.180",
+		MacAddress: "00:0b:ab:98:ba:cf",
+		Type:       "EC-200",
+	})
+}


### PR DESCRIPTION
See #22

* Fix `discovery:Packet.unpackHostname` to skip `"N/A"` fields
* Fix `client:Options.DiscoverFilter` to filter out non-VP discovery packets (XMLPort is `N/A` => 0)