### PR TITLE
Fix tally discovery handling

### DIFF
--- a/client/discovery.go
+++ b/client/discovery.go
@@ -8,8 +8,17 @@ import (
 
 // Returns client Options for the given discovery packet
 func (options Options) DiscoverOptions(discoveryPacket discovery.Packet) (Options, error) {
-	options.Address = discoveryPacket.IP.String()
-	options.XMLPort = fmt.Sprintf("%d", discoveryPacket.XMLPort)
+	if len(discoveryPacket.IP) == 0 {
+		return options, fmt.Errorf("Invalid discovery IP=%#v", discoveryPacket.IP)
+	} else {
+		options.Address = discoveryPacket.IP.String()
+	}
+
+	if discoveryPacket.XMLPort == 0 {
+		return options, fmt.Errorf("Invalid discovery XMLPort=%#v", discoveryPacket.XMLPort)
+	} else {
+		options.XMLPort = fmt.Sprintf("%d", discoveryPacket.XMLPort)
+	}
 
 	return options, nil
 }

--- a/tally/tally.go
+++ b/tally/tally.go
@@ -117,11 +117,11 @@ func (tally *Tally) Run() error {
 			if !valid {
 				return fmt.Errorf("discovery: %v", tally.discovery.Error())
 			} else if clientOptions, err := tally.options.clientOptions.DiscoverOptions(discoveryPacket); err != nil {
-				log.Printf("Tally: invalid discovery client options: %v\n", err)
+				log.Printf("Tally: invalid discovery client options for %v: %v\n", discoveryPacket.IP, err)
 			} else if source, exists := tally.sources[clientOptions.String()]; exists && source.err == nil {
 				// already running
 			} else if source, err := newSource(tally, discoveryPacket, clientOptions); err != nil {
-				log.Printf("Tally: unable to connect to discovered system: %v\n", err)
+				log.Printf("Tally: unable to connect to discovered system at %v: %v\n", clientOptions, err)
 			} else {
 				log.Printf("Tally: connected to source: %v\n", source)
 


### PR DESCRIPTION
Continues #25 

The `tally:Tally` was not using `client:Options.DiscoverFilter`, and would try to connect to `XMLPort=0`... have it fail on the `client:Options.DiscoverOptions` instead.

This would still need some improvements to extend the `tally:newSource` logic of not connecting to slave VPs to also not connect to non-VP devices... now the tally will log errors for each discovery packet, instead of listing the device as a non-connected source. That is going to be too awkward to test without actual devices, though.