### PR TITLE
Switch back to upstream github.com/kidoman/embd with fixes

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -20,15 +20,14 @@
   version = "v1.4.0"
 
 [[projects]]
-  branch = "digitalpin-exported"
+  branch = "master"
   name = "github.com/kidoman/embd"
   packages = [
     ".",
     "host/generic",
     "host/rpi"
   ]
-  revision = "780d9e92acefc982f3c9b4edb0e46202137f597c"
-  source = "github.com/SpComb/embd"
+  revision = "d3d8c0c5c68dc6caccebb7d720f36e64bafd0a62"
 
 [[projects]]
   name = "github.com/kr/pretty"
@@ -89,6 +88,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "af2ba16a84f788d2178c82f47941a79e255b4b64699e7ae63d7a1dcee801a925"
+  inputs-digest = "84859f212a212f9906cf4eedc6d9eb5c0e629037ee93d9626736249a57b5cccb"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -31,8 +31,7 @@
 
 [[constraint]]
   name = "github.com/kidoman/embd"
-  source = "github.com/SpComb/embd"
-  branch = "digitalpin-exported"
+  branch = "master"
 
 [[constraint]]
   name = "github.com/kr/pretty"


### PR DESCRIPTION
Fixes  #29

Switch back to the upstream github.com/kidoman/embd from our own [fork](https://github.com/kidoman/embd/compare/master...SpComb:digitalpin-exported), it now has the relevant fixes merged:

* https://github.com/kidoman/embd/commit/c1886eb5bf22bf655793ce7c50491175de95923f
* https://github.com/kidoman/embd/pull/68/commits/091d6f558821db718702f1dd9636637d2c429d6f
* https://github.com/kidoman/embd/commit/1e99d1ac2d1ebab3faf03fcf7d6fcf78ea9ef824