### PR TITLE
Tally: fix BG sources to ignore matte layers

### DIFF
--- a/tally/source.go
+++ b/tally/source.go
@@ -214,7 +214,7 @@ func (source Source) updateState(state *State) error {
 			}
 
 			for bgIndex, bgLayer := range screen.BGLyr {
-				if bgLayer.LastBGSourceIndex == bgSourceID {
+				if bgLayer.LastBGSourceIndex == bgSourceID && bgLayer.ShowMatte == 0 {
 					if bgIndex == screen.CurrBGLyr {
 						status.Program = true
 					} else {


### PR DESCRIPTION
Fixes #40

Background source input tally would remain active when a BG layer was set to matte.